### PR TITLE
Basic implementation of connected line mode for Graphlot (0.9.x)

### DIFF
--- a/webapp/content/js/jquery.graphite.js
+++ b/webapp/content/js/jquery.graphite.js
@@ -112,6 +112,16 @@
             // parameter to construct the id's of the elements to interact with (see above)
             var graph = config.graph
 
+            // parameter to change line mode
+            var linemode = (typeof config.linemode === 'undefined') ? '' : config.linemode.toLowerCase();
+
+            // parameter to define max consecutive nulls to be removed from a series
+            var maxnulls = 0;
+            if (linemode == 'connected') {
+                        maxnulls = (typeof config.connectedlimit === 'undefined' || config.connectedlimit == '') ? -1 : parseInt(config.connectedlimit);
+                        if (isNaN(maxnulls)) maxnulls = 0;
+            }
+
             var plot = null;
             var graph_lines = {};
             var metric_yaxis = {};
@@ -132,10 +142,18 @@
                 var start = incoming_data.start;
                 var end = incoming_data.end;
                 var step = incoming_data.step;
+                var nullcount = 0;
 
                 for (i in incoming_data.data) {
+                    if (maxnulls != 0) {
+                        if (incoming_data.data[i] == null) {
+                            nullcount++;
+                        } else if (nullcount > 0) {
+                            if (maxnulls == -1 || nullcount <= maxnulls) result.splice(-nullcount, nullcount);
+                            nullcount = 0;
+                        }
+                    }
                     result.push([(start+step*i)*1000, incoming_data.data[i]]);
-
                 }
                 return {
                     label: incoming_data.name,

--- a/webapp/graphite/graphlot/views.py
+++ b/webapp/graphite/graphlot/views.py
@@ -23,11 +23,15 @@ def graphlot_render(request):
     untiltime = request.GET.get('until', "-0hour")
     fromtime = request.GET.get('from', "-24hour")
     events = request.GET.get('events', "")
+    linemode = request.GET.get('lineMode', "")
+    connectedlimit = request.GET.get('connectedLimit', "")
     context = {
       'metric_list' : metrics,
       'fromtime' : fromtime,
       'untiltime' : untiltime,
       'events' : events,
+      'linemode' : linemode,
+      'connectedlimit' : connectedlimit,
       'slash' : get_script_prefix()
     }
     return render_to_response("graphlot.html", context)

--- a/webapp/graphite/templates/graphlot.html
+++ b/webapp/graphite/templates/graphlot.html
@@ -16,7 +16,7 @@
     var SLASH='{{slash}}';
 
     $(document).ready(function () {
-        $('#g_wrap').graphiteGraph();
+        $('#g_wrap').graphiteGraph({linemode: '{{linemode}}', connectedlimit: '{{connectedlimit}}'});
     });
 
     </script>


### PR DESCRIPTION
This patch provides connected line functionality for Graphlot.  After this patch has been applied, clicking "Open in Graphlot" on a graph from Graphite-web will cause Graphlot to inherit connected line mode and connected line limit if currently active.
