### PR TITLE
Graphlot - enable dynamic template selection using special URLs (master)

### DIFF
--- a/webapp/graphite/graphlot/views.py
+++ b/webapp/graphite/graphlot/views.py
@@ -32,7 +32,14 @@ def graphlot_render(request):
       'events' : events,
       'slash' : get_script_prefix()
     }
-    return render_to_response("graphlot.html", context)
+
+    match = re.match('^/graphlot/([a-zA-Z0-9\-_]+)$', request.path)
+    if match:
+      templates = ['graphlot_' + match.group(1) + '.html', 'graphlot.html']
+    else:
+      templates = 'graphlot.html'
+
+    return render_to_response(templates, context)
 
 def get_data(request):
     """Get the data for one series."""


### PR DESCRIPTION
This patch enables the dynamic selection of Graphlot HTML templates by changing the URL.  For example, a url like http://graphite/graphlot/embed?width=586&height=308... will use the graphlot_embed.html template (if it exists).  If the URL implies a template that does not exist, django automatically falls back to the standard graphlot.html template.
