### PR TITLE
Graphlot - Incorrect representation of null points in legend (0.9.x)

### DIFF
--- a/webapp/content/js/jquery.graphite.js
+++ b/webapp/content/js/jquery.graphite.js
@@ -220,9 +220,9 @@
 
                     // now interpolate
                     var y, p1 = series.data[j - 1], p2 = series.data[j];
-                    if (p1 == null)
+                    if (p1 == null || p1[1] == null)
                         y = p2[1];
-                    else if (p2 == null)
+                    else if (p2 == null || p2[1] == null)
                         y = p1[1];
                     else
                         y = p1[1] + (p2[1] - p1[1]) * (pos.x - p1[0]) / (p2[0] - p1[0]);


### PR DESCRIPTION
Null values were being treated as zero by the Graphlot legend.  The result was that the legend displayed phantom values approaching zero (as distance from the last real not null value increased), then zero (for all x values where there are no proximal not null values) and then phantom values approaching the next not null value (as the distance to the next real not null value decreased) if one exists.  Clear as mud?  Basically it wasn't working properly.

This patch ensures the points are inspected for null values, instead of just checking that the points exist (they only don't exist at the beginning and end of the series).
