### PR TITLE
Graphlot - Patch to fix incompatibility introduced by 28bbd7f9

### DIFF
--- a/webapp/graphite/graphlot/views.py
+++ b/webapp/graphite/graphlot/views.py
@@ -38,6 +38,7 @@ def get_data(request):
     requestContext = {
         'startTime' : requestOptions['startTime'],
         'endTime' : requestOptions['endTime'],
+        'now': requestOptions['now'],
         'localOnly' : False,
         'data' : []
     }


### PR DESCRIPTION
https://github.com/Kixeye/graphite-web/commit/28bbd7f9abf9daef102601f673bd6fdac679542a introduced the requirement of a 'now' key in the requestContext parameter passed to fetchData in webapp/graphite/render/datalib.py.  This patch makes Graphlot compatible with this change.
