### PR TITLE
Add optional 'now' parameter to remote fetch (0.9.x)

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -103,7 +103,7 @@ class RemoteNode:
     self.__isLeaf = isLeaf
 
 
-  def fetch(self, startTime, endTime):
+  def fetch(self, startTime, endTime, now=None):
     if not self.__isLeaf:
       return []
 
@@ -113,6 +113,8 @@ class RemoteNode:
       ('from', str( int(startTime) )),
       ('until', str( int(endTime) ))
     ]
+    if now is not None:
+      query_params.append(('now', str( int(now) )))
     query_string = urlencode(query_params)
 
     connection = HTTPConnectionWithTimeout(self.store.host)


### PR DESCRIPTION
Bring remote fetch in line with local fetch by incorporating new 'now' parameter.
